### PR TITLE
RFC: Dynamic import hints

### DIFF
--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -1,0 +1,71 @@
+---
+title: Dynamic Import Hints and Its Metadata
+status: ACTIVE
+
+created_at: 2020-03-16
+updated_at: 2020-03-16
+---
+
+# Hints Authoring Syntax and Its Metadata
+
+## Summary
+This RFC suggests authoring syntax for specifying dynamic import hints and describes its metadata shape.
+
+## Motivation
+The Hints in dynamic components allows component authors to declare the hint context by parameterizing dynamic imports. The values from the hints can be used to optimize dependency resolution and pre-fetching.
+
+## Detailed design
+
+### Hints Syntax
+Hints are expressed as a comment inside a dynamic import expression. 
+The hint syntax is a block string with a *key *as a resource and a *value* as a resolved resource value
+
+```js
+/* <key>=<value> */
+```
+Hint comment ex:
+```js
+/* @salesforce/client/formFactor=Small */
+```
+
+Dynamic Import with Hint ex:
+```js
+export async function example1() {
+    loadedModule = await import("lightning-foo"/* @salesforce/client/formFactor=Small */);
+}
+```
+
+### Reasons
+The hint syntax in a form of a comment was selected for the following reasons:
+* complies with ‘what you write is what you see’ concept - an originally authored code remains untouched
+* eliminates any additional code transformations at compiler time
+* eliminates any additional processing during module resolution at runtime (to strip out or pre-process module name)
+
+### Hint Invariants
+* hint values must be globally available and resolvable on the server side 
+* hint values must be statically verifiable
+* hint values must be finite and enumerable (ex: no Math.random())
+
+### Dynamic Import Metadata
+The proposed metadata format will include a dynamically imported component name and a hint object, which in-itself contains the original query and a hint value. A hint value will be an array of objects with raw hint query, expected hint condition, and hint resource information.
+
+Proposed Shape
+```js
+{
+  dynamicImports: [{
+    moduleName: "lightning-foo",
+    file: "foo.js"
+    hints: [
+                rawValue: "/* @salesforce/client/formFactor=Small */"
+                resource: {
+                    id: "@salesforce/client/formFactor",
+                    namespacedId: undefined, // scoped modules are namespaced at compile time
+                    type: "client",
+                    file: "foo.js",
+                    location: {...}
+                },
+                value: "Small", 
+    ]
+  }]
+}
+```

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -39,7 +39,7 @@ Using hints allows component authors to specify a condition on which a dynamic i
 ## Detailed Design
 
 ### Grammar
-This section defines the grammar to be followed for hints so that the compiler can parse component modules, gather hints metadata and provide that as part of the compilation result.
+This section defines the grammar to be followed for expressing hints. The grammar establishes a contract between the component and the compiler to facilitate hint recognition by the compiler, gathering the metadata and providing that as part of the compilation result.
 
 #### Hint Syntax
 A hint is expressed as a comment inside a dynamic import expression. The hint syntax is either a line comment or a block comment with a *key* and *value* pair. The key and value will be separated by a colon(`:`) and delimited using double quotes(`"`).

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -40,7 +40,7 @@ Using hints allows component authors to specify a condition on which a dynamic i
 ## Detailed Design
 
 ### Grammar
-There will be grammar restriction in place for hints so that the compiler can parse  component modules, gather metadata and provide that as part of compilation result.
+There will be grammar restrictions in place for hints so that the compiler can parse component modules, gather metadata and provide that as part of the compilation result.
 
 #### Hint Syntax
 A hint is expressed as a comment inside a dynamic import expression. The hint syntax is either a line comment or a block comment with a *key* and *value* pair. The key and value will be separated by a colon(`:`) and delimited using double quotes(`"`).
@@ -141,7 +141,7 @@ Dynamic imports hint metadata gathering happens during component compilation. An
 
 Additional validation and post processing of the gathered metadata is out of the scope of this RFC. That logic will be the responsibility of the application framework that consumes the metadata.
 
-Similarly, any design time validations of the hint grammar should be handled by linting code. For example, on salesforce platform, allowed hint keys might be restricted to only `@salesforce` scoped specifiers. The hint values will be validated based on the relevant value for the specifier. An ESLint rule will enforce this restriction via the [eslint-plugin-lwc](https://github.com/salesforce/eslint-plugin-lwc).
+Similarly, static analysis of dynamic import hints can be handled by linting module code. For example, on salesforce platform, allowed hint keys might be restricted to only `@salesforce` scoped specifiers. The hint values will be validated based on the relevant value for the specifier. An ESLint rule will enforce this restriction via the [eslint-plugin-lwc](https://github.com/salesforce/eslint-plugin-lwc).
 
 ### Reasons
 The hint syntax in the form of a comment was selected for the following reasons:

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -2,78 +2,197 @@
 title: Dynamic Import Hints and Its Metadata
 status: DRAFTED
 created_at: 2020-03-16
-updated_at: 2020-03-16
+updated_at: 2020-03-22
 rfc: https://github.com/salesforce/lwc-rfcs/pull/27
 champion: Aliaksandr Papko (@apapko) | LWC Team
-implementation: 228
+implementation: https://git.soma.salesforce.com/lwc/lwc-api/pull/42 & https://git.soma.salesforce.com/lwc/lwc-platform/pull/361
 ---
 
 # Hints Syntax and Its Metadata
+
+Table of Content:
+* [Summary](#summary)
+* [Motivation](#motivation)
+* [Detailed Design](#detailed-design)
+    * [Grammar](#grammar)
+        * [Hint Syntax](#hint-syntax)
+        * [Static Semantics](#static-semantics)
+        * [Semantics](#semantics)
+        * [Examples](#examples)
+        * [Separation of Concern](#separation-of-concern)
+    * [Reasons](#reasons)
+    * [Dynamic Import Metadata](#dynamic-import-metadata)
+* [Alternate Syntax Considered](#alternate-syntax-considered)
+* [Future work](#future-work)
+* [References](#references)
 
 ## Summary
 This RFC suggests authoring syntax for specifying dynamic import hints and describes its metadata shape.
 
 ## Motivation
-Using hints allow component authors to declare the component preload context by parameterizing dynamic imports. The values from the hints can be used to optimize dependency resolution and pre-fetching.
+Using hints allows component authors to specify a condition on which a dynamic import will be necessary. This is a way to describe the conditions required for this import to happen. An application framework can use these hints to optimize the loading of those resources (e.g.: pre-fetch at the time of resolving dependencies)
 
 ## Hint Invariants
-* hint values must be globally available and resolvable on the server side 
-* hint values must be statically verifiable
-* hint values must be finite and enumerable (ex: no Math.random())
+* Hint key and value are string literals
+* Hint key and value must be statically verifiable i.e. no curly braces to implicitly refer to a variable and such
+* Hints do not influence the outcome of the compilation phase. It only produces additional metadata for the application framework to consume.
 
-## Detailed design
+## Detailed Design
 
-### Hints Syntax
-Hints are expressed as a comment inside a dynamic import expression. 
-The hint syntax is a block string with a *key *as a resource and a *value* as a resolved resource value
+### Grammar
+There will be grammar restriction in place for hints so that the compiler can parse  component modules, gather metadata and provide that as part of compilation result.
+
+#### Hint Syntax
+A hint is expressed as a comment inside a dynamic import expression. The hint syntax is either a line comment or a block comment with a *key* and *value* pair. The key and value will be separated by a colon(`:`) and delimited using double quotes(`"`).
 
 ```js
-/* <key>=<value> */
+/* "<key>": "<value>" */
 ```
-Hint comment ex:
+Hint comment e.g.:
 ```js
-/* @salesforce/client/formFactor=Small */
+/* "@salesforce/client/formFactor": "SMALL" */
+/* "MY_CONDITION": "VALID" */
+// "MY_OTHER_CONDITION": "NOT_VALID"
 ```
 
-Dynamic import with a hint ex:
+Dynamic import with a hint e.g.:
 ```js
-export async function example1() {
-    loadedModule = await import("lightning-foo"/* @salesforce/client/formFactor=Small */);
+import formFactor from '@salesforce/client/formFactor';
+
+export async function loadFoo() {
+    if (formFactor === 'SMALL') {
+        return import("lightning-foo-mobile" /* "@salesforce/client/formFactor": "SMALL" */);
+    } else {
+        return import("lightning-foo-desktop" /* "@salesforce/client/formFactor": "LARGE" */);
+    }
 }
 ```
 
-### Reasons
-The hint syntax in a form of a comment was selected for the following reasons:
-* complies with ‘what you write is what you see’ concept - an originally authored code remains untouched
-* eliminates any additional code transformations at compile time
-* eliminates any additional processing during module resolution at runtime (to strip out or pre-process module name)
+#### Static Semantics
+* Both key and value have to be string literal
+* Is case sensitive
+* Key and value have to be delimited with a double quote to be explicit about the literal value
+* Spaces before and after the colon(`:`) is optional
+* Hint phrase can have leading and trailing spaces
 
+##### Hint Key:
+* First character is an alphabet, can be uppercase or lower case. Can also start with `@` character
+* Cannot contain any special characters except for underscore(`_`), hyphen(`-`), dot(`.`) and forward slash(`/`)
+* Begins and ends with a double quote(`"`)
+* Cannot contain spaces, cannot be delimited by a single quote(`'`)
+
+##### Hint Value:
+* Can contain alphanumeric characters
+* Can contain space, underscore(`_`), hyphen(`-`), at sign(`@`), forward slash(`/`)
+* Cannot combine multiple values using operators(i.e `"KEY": "LARGE"&"SMALL"` or `"KEY": "LARGE && SMALL"` will not qualify as a valid hint)
+
+##### Mutiple Hints:
+When multiple hint comments are specifed for a single dynamic import statement, only the fist hint is considered.
+Example:
+```js
+import("c-bar-mobile"
+    /* "@salesforce/client/formFactor": "SMALL"*/
+    /* "@salesforce/userPermission/ViewSetup": "true"*/
+);
+```
+In the above example, only the `formFactor` hint is considered.
+
+#### Semantics
+The [_ModuleSpecifier_](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-imports) of the import statement should be a string literal. The compiler cannot analyze data about a module name that will be discovered or learned at runtime. For example, in the following case no hint metadata will be gathered:
+```js
+const bar = '/modules/my-module.js';
+function foo() {
+    import(
+        bar
+        /* "@salesforce/client/formFactor": "SMALL" */
+    ).then(module => {
+        success();
+    });
+}
+```
+If a hint does not follow the above grammar, metadata gathering for that specific hint will be skipped. However, if there are other hints in the same module that follow the grammar, metadata will be gathered.
+
+#### Examples
+Valid
+```js
+// Single hint
+import("c-bar-mobile"/* "@salesforce/client/formFactor": "SMALL"*/);
+import("c-bar-mobile"/* "KEY.SUBKEY": "VALUE"*/);
+import("c-bar-mobile"/* "KEY/SUBKEY1": "VALUE"*/);
+import("c-bar-mobile"/* "KEY": "true"*/);
+import("c-bar-mobile"/* "KEY": "1"*/);
+```
+Invalid
+```js
+import("c-bar-mobile"/* "KEY SUBKEY": "SMALL"*/);
+import("c-bar-mobile"/* "😀": "1"*/);
+import("c-bar-mobile"/* @salesforce/client/formFactor = SMALL*/);
+
+import("c-bar-mobile" /* "@salesforce/client/formFactor": "SMALL && LARGE"*/);
+import("c-bar-mobile" /* "@salesforce/client/formFactor": "SMALL" && "@salesforce/client/formFactor": "LARGE"*/);
+
+// Dynamic module name specifier
+const bar = 'module-name';
+import(bar/* "@salesforce/client/formFactor": "SMALL" */)
+```
+
+#### Separation of Concern
+Dynamic imports hint metadata gathering happens during component compilation. An invariant of this process is that the metadata collection will **not** fail due to a bad hint. This could be due to a hint not following specified grammar or not using a well understood hint value.
+
+Additional validation and post processing of the gathered metadata is out of the scope of this RFC. That logic will be the responsibility of the application framework that consumes the metadata.
+
+Similarly, any design time validations of the hint grammar should be handled by linting code. For example, on salesforce platform, allowed hint keys might be restricted to only `@salesforce` scoped specifiers. The hint values will be validated based on the relevant value for the specifier. An ESLint rule will enforce this restriction via the [eslint-plugin-lwc](https://github.com/salesforce/eslint-plugin-lwc).
+
+### Reasons
+The hint syntax in the form of a comment was selected for the following reasons:
+* Complies with ‘what you write is what you see’ concept - an originally authored code remains untouched
+* Eliminates any additional code transformations at compile time
+* Eliminates any additional processing during module resolution at runtime (to strip out or pre-process module name)
 
 ### Dynamic Import Metadata
 The proposed metadata format will include dynamically imported component name and a hint object, which in-itself contains the original query and a hint value. A hint value will be an array of objects with raw hint query, expected hint condition, and hint resource information.
 
-Proposed Shape
-```js
-{
-  dynamicImports: [{
-    moduleName: "lightning-foo",
-    file: "foo.js"
-    hints: [
-                rawValue: "/* @salesforce/client/formFactor=Small */"
-                resource: {
-                    id: "@salesforce/client/formFactor",
-                    namespacedId: undefined, // scoped modules are namespaced at compile time
-                    type: "client",
-                    file: "foo.js",
-                    location: {...}
-                },
-                value: "Small", 
-    ]
-  }]
+#### Proposed Shape
+```ts
+export interface SourceLocation {
+    startLine: number;
+    startColumn: number;
+    endline: number;
+    endColumn: number;
+    file: string;
+}
+
+export interface DynamicImportHint {
+    rawValue: string; // Trimmed hint phrase
+    hintKey: string;
+    hintValue: string;
+    location: SourceLocation;
+}
+
+export interface DynamicImportMetadata {
+    moduleName: string;
+    file: string;
+    hints: DynamicImportHint[];
 }
 ```
 
-## Other Options Considered
+Example:
+```js
+{
+    dynamicImports: [{
+        moduleName: 'lightning-foo',
+        file: 'foo.js',
+        hints: [{
+            rawValue: '"@salesforce/client/formFactor": "SMALL"',
+            hintKey: '@salesforce/client/formFactor',
+            location: {...},
+            hintValue: 'SMALL',
+        }]
+    }]
+}
+```
+
+## Alternate Syntax Considered
 
 ### Hints as a query attached to the component name
 The hint syntax is a parameterized query appended to the component name:
@@ -85,12 +204,12 @@ export async function example1() {
 
 *Pros:*
 
-* intuitive syntax 
+* Intuitive syntax
 
 *Cons:*
 
-* requires transform to remove the query 
-* using a query string syntax to discover modules to prefetch doesn't align with the way standard import() works. JavaScript VM caches modules by URL (including the query string), this means that lightning-foo lightning-foo?1 and lightning-foo?2 are 3 different JavaScript module instances. 
+* Requires transform to remove the query
+* Using a query string syntax to discover modules to prefetch doesn't align with the way standard import() works. JavaScript VM caches modules by URL (including the query string), this means that lightning-foo lightning-foo?1 and lightning-foo?2 are 3 different JavaScript module instances
 
 ### Hints via proprietary LWC function
 The hint syntax is expressed via a proprietary lwc function, where the first parameter is a component name and the second parameter is a query object - hintImport(cmpName, queryObj). At compile time, the function will be transformed into a regular import without a string. Note, the hint is consumed by metadata parser only, which is traversed outside of the compilation sequence on the original source. Therefore, it is safe to have a ‘throw-away’ wrapper that will be eliminated at compiler time.  
@@ -118,13 +237,21 @@ export async function example1() {
 
 *Pros:*
 
-* dedicated syntax
-* full control of the hint shape
-* having to explicitly define a resource reference will allow for ref integrity support if required
+* Dedicated syntax
+* Full control of the hint shape
+* Having to explicitly define a resource reference will allow for ref integrity support if required
 
 *Cons:*
 
-* requires an additional transform
-* requires knowledge of syntax existence
-* maintanance burden
+* Requires an additional transform
+* Requires knowledge of syntax existence
+* Maintanance burden
 
+## Future work
+* Support for multiple hints for a dynamic import statement, with usage of operators to combine hints and hint values
+* Support for other primitive data types like boolean, number as hint values
+* Support for JSON string as hint value to represent an object
+
+## References
+* [RFC - Dynamic component creation](https://github.com/salesforce/lwc-rfcs/blob/master/text/0110-dynamic-components.md)
+* [RFC - Pivots in LWC](https://salesforce.quip.com/En4UA5EtbKc0) (_restricted access_)

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -1,9 +1,11 @@
 ---
 title: Dynamic Import Hints and Its Metadata
-status: ACTIVE
-
+status: DRAFTED
 created_at: 2020-03-16
 updated_at: 2020-03-16
+rfc: https://github.com/salesforce/lwc-rfcs/pull/27
+champion: Aliaksandr Papko (@apapko) | LWC Team
+implementation: 228
 ---
 
 # Hints Authoring Syntax and Its Metadata

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -124,11 +124,6 @@ Invalid
 import("c-bar-mobile"/* "KEY SUBKEY": "SMALL"*/);
 import("c-bar-mobile"/* @salesforce/client/formFactor = SMALL*/);
 
-// Operators
-import("c-bar-mobile" /* "@salesforce/client/formFactor": "SMALL" && "LARGE"*/);
-import("c-bar-mobile" /* "@salesforce/client/formFactor": "SMALL" && "@salesforce/client/formFactor": "LARGE"*/);
-import("c-bar-mobile" /* "@salesforce/userPermission/ViewSetup" && "@salesforce/userPermission/EditSetup": "true"*/);
-
 // Dynamic module name specifier
 const bar = 'module-name';
 import(bar/* "@salesforce/client/formFactor": "SMALL" */)

--- a/text/0000-dynamic-import-hints.md
+++ b/text/0000-dynamic-import-hints.md
@@ -8,7 +8,7 @@ champion: Aliaksandr Papko (@apapko) | LWC Team
 implementation: 228
 ---
 
-# Hints Authoring Syntax and Its Metadata
+# Hints Syntax and Its Metadata
 
 ## Summary
 This RFC suggests authoring syntax for specifying dynamic import hints and describes its metadata shape.

--- a/text/0112-dynamic-import-hints.md
+++ b/text/0112-dynamic-import-hints.md
@@ -1,8 +1,8 @@
 ---
 title: Dynamic Import Hints and Its Metadata
-status: DRAFTED
+status: APPROVED
 created_at: 2020-03-16
-updated_at: 2020-03-22
+updated_at: 2020-03-31
 rfc: https://github.com/salesforce/lwc-rfcs/pull/27
 champion: Aliaksandr Papko (@apapko) | LWC Team
 implementation: https://git.soma.salesforce.com/lwc/lwc-api/pull/42 & https://git.soma.salesforce.com/lwc/lwc-platform/pull/361


### PR DESCRIPTION
This RFC proposes the syntax and metadata format for using hints with dynamic imports.

Relevant information to know before reading this RFC:
1. https://github.com/salesforce/lwc-rfcs/blob/master/text/0110-dynamic-components.md