### PR TITLE
fixing exposed example

### DIFF
--- a/text/0020-module-resolution.md
+++ b/text/0020-module-resolution.md
@@ -276,9 +276,9 @@ In order to expose a module via npm package, it must be explicity declared in th
        }     
     ],
     "expose": [
-        "ui-foo",
-        "ui-bar",
-        "ltng-buzz",
+        "ui/foo",
+        "ui/bar",
+        "ltng/buzz",
     ]
 }
 ```


### PR DESCRIPTION
Fixes _expose_ example, changing from `ui-foo` to `ui/foo`