### PR TITLE
docs: update spellcheck rfc to implemented

### DIFF
--- a/text/0000-spellcheck-global-attribute.md
+++ b/text/0000-spellcheck-global-attribute.md
@@ -3,7 +3,7 @@ title: Spellcheck Attribute
 status: IMPLEMENTED
 created_at: 2019/11/15
 updated_at: 2020/05/26
-champion: Eugene Kashida (ekashida)
+champion: Jose David Rodriguez Velasco (jodarove)
 implementation: https://github.com/salesforce/lwc/pull/1610
 pr: https://github.com/salesforce/lwc-rfcs/pull/21
 ---

--- a/text/0000-spellcheck-global-attribute.md
+++ b/text/0000-spellcheck-global-attribute.md
@@ -1,8 +1,10 @@
 ---
 title: Spellcheck Attribute
-status: DRAFTED
+status: IMPLEMENTED
 created_at: 2019/11/15
-updated_at: 2019/11/20
+updated_at: 2020/05/26
+champion: Eugene Kashida (ekashida)
+implementation: https://github.com/salesforce/lwc/pull/1610
 pr: https://github.com/salesforce/lwc-rfcs/pull/21
 ---
 


### PR DESCRIPTION
Update the spellcheck-global-attribute RFC to "implemented". This is implemented since Feb 2020.
https://github.com/salesforce/lwc/pull/1610