### PR TITLE
fix: update template refs with better backwards compat

### DIFF
--- a/text/0000-refs.md
+++ b/text/0000-refs.md
@@ -117,6 +117,10 @@ In the case of shadow DOM components, `this.refs` refers to elements inside of t
 
 To preserve backwards compatibility with existing components that may have defined a `refs` property, `refs` will be configurable and writable, so if a component defines its own `refs`, it will replace the one from `LightningElement.prototype`.
 
+To further improve backwards compatibility, the `refs` property will only be defined if the directive `lwc:ref` is present somewhere in the template. If `lwc:ref` is not defined in the template, then `this.refs` returns undefined.
+
+In the case of a component that renders multiple templates, the presence or absence of `lwc:ref` is checked on-demand in the `this.refs` getter. So whether `this.refs` is undefined or an object will depend on the current template when the `this.refs` getter is invoked.
+
 ### Multiple templates
 
 In the case of multiple templates, the same rules as for `this.template.querySelector()` or `this.querySelector()` apply. Once the new template is rendered, `this.refs` refers to elements defined in the new template:


### PR DESCRIPTION
This updates the "template refs" proposal with betters backwards compatibility with existing Lightning Web Components.