### PR TITLE
docs: fix typos and grammar in RFC documents

### DIFF
--- a/text/0000-focus-behavior.md
+++ b/text/0000-focus-behavior.md
@@ -79,7 +79,7 @@ us, we can instead:
    sequentially focusable elements and the set of elements with a negative
    tabindex content attribute value.
 1. Verify that the element received focus via `activeElement`.
-1. If the element did not recieve focus then keep invoking the focus method on
+1. If the element did not receive focus then keep invoking the focus method on
    subsequent elements until we verify that focus was transferred.
 
 The verification step is useful as a workaround for implementation bugs around

--- a/text/0000-intl.md
+++ b/text/0000-intl.md
@@ -12,16 +12,16 @@ Provide best-in-class localization infrastructure for Lightning Web Components.
 
 * As a developer, I can opt-in to localize my template.
 * As a developer, I can interpolate text, variables and HTML tags.
-* As a developer, I can format number and dates in my template.
+* As a developer, I can format numbers and dates in my template.
 * As a developer, I can select from different statements in my template.
-* As a developer, I can use grammatically to format nouns based on app configurations.
+* As a developer, I can use grammar to format nouns based on app configurations.
 * As a developer, I can pluralize sentences based on numeric values.
 
 ## Proposal 1: Fluent Subset
 
-This proposal is heavily influenced by [Fluent](http://projectfluent.io/) from Mozilla. And introduces a new template directive called `intl` that can be use to specify certain things in the template.
+This proposal is heavily influenced by [Fluent](http://projectfluent.io/) from Mozilla. And introduces a new template directive called `intl` that can be used to specify certain things in the template.
 
-The most basic step is to define the id of the translation bundle by using `<template intl:id="something">`, which means that the `template` can be localized/localized by parsing the HTML, and extracting the labels from it. This signals to the compiler that extra work is required during compilation to extra all the labels and produce a localization bundle per component.
+The most basic step is to define the id of the translation bundle by using `<template intl:id="something">`, which means that the `template` can be localized/localized by parsing the HTML, and extracting the labels from it. This signals to the compiler that extra work is required during compilation to extract all the labels and produce a localization bundle per component.
 
 ### Template Grammar
 
@@ -72,7 +72,7 @@ The first argument is the name of the noun (will be used as a fallback value). T
 
 Optional attributes:
 
- * case: (`n`)moninative | (`a`)ccusative | (`g`)enitive | (`d`)ative | (`o`)bjective | (`s`)ubjective - default is `n`
+ * case: (`n`)nominative | (`a`)ccusative | (`g`)enitive | (`d`)ative | (`o`)bjective | (`s`)ubjective - default is `n`
  * plural: (`y`)es | (`n`)o - default is `n`
  * article: (`n`)one | (`a`) | (`the`) | (`d`)efinite | (`i`)ndefinite  - default is `n`
 
@@ -128,7 +128,7 @@ The pluralization is just a more specific selection mechanism by using the `PLUR
 
 #### Attributes
 
-This proposal does not include any advanced option for HTML attributes. Which means that built-in functions and advanced interpolation are not possible for HTML attribute. However, it does exact certain elements and attributes that are allowed for localization. E.g.:
+This proposal does not include any advanced option for HTML attributes. Which means that built-in functions and advanced interpolation are not possible for HTML attribute. However, it does extract certain elements and attributes that are allowed for localization. E.g.:
 
 ```html
 <template intl:id="bundle5">
@@ -150,7 +150,7 @@ For custom elements, since we do not know what is localizable or not, the develo
 </template>
 ```
 
-In the example above, even though the compiler does not know what `tooltip` attributes is, it will extract it for localization because it is marked with the `intl:` directive.
+In the example above, even though the compiler does not know what `tooltip` attribute is, it will extract it for localization because it is marked with the `intl:` directive.
 
 ### Lightning Web Components vs Fluent
 
@@ -221,9 +221,9 @@ where `"a few seconds ago"` is a relative time formatted value, and `"50+ items"
 
 > 1. `"You need to specify a contact on the case first."`
 
-where `"a contact"` is an entitity (`<contact article="a"/>`) and `"the case"` is an entitye as well (`<case article="the"/>`).
+where `"a contact"` is an entity (`<contact article="a"/>`) and `"the case"` is an entity as well (`<case article="the"/>`).
 
-#### label with embeded HTML (including attributes)
+#### label with embedded HTML (including attributes)
 
 > 1. `"<strong>Note:</strong> See Merge Fields Below"`
 

--- a/text/0111-feature-flags.md
+++ b/text/0111-feature-flags.md
@@ -15,7 +15,7 @@ This RFC defines the infrastructure pieces to support feature flags to enable ex
 
 * It is becoming more difficult to add new features to engine and compiler due to the potential breaking hazard.
 * Some features need a period of adaptation and testing before we allow LWC users to consume them, but today the only option is to keep them in a separate branch forever.
-* The performance implications of a change is sometimes difficult to assess without hitting production servers, but at that point, it is too late since everyone has access to the same set of features today.
+* The performance implications of a change are sometimes difficult to assess without hitting production servers, but at that point, it is too late since everyone has access to the same set of features today.
 * Branching code logic for certain features (e.g., slotchange event) is becoming more complicated over time, and having that in the actual code makes the code less readable.
 * Polyfilling new shadow dom semantics is almost impossible considering that we know it is going to break LWC users at some point.
 
@@ -122,7 +122,7 @@ TBD
 
 ### Enabling At Runtime
 
-This could be achieve via the global LWC configuration, e.g.:
+This could be achieved via the global LWC configuration, e.g.:
 
 ```js
 // client side configuration

--- a/text/0123-innerhtml-binding.md
+++ b/text/0123-innerhtml-binding.md
@@ -11,7 +11,7 @@ champion: Philippe Riand, Pierre-Marie Dartus
 
 ## Summary
 
-Applications dealing with rich content, like commerce apps, need to render this content as raw HTML, coming from a database or a CMS. Today, there is no way in LWC to rendered raw HTML content both on the browser and the server. This proposal introduces the `lwc:inner-html` template directive to inject HTML content.
+Applications dealing with rich content, like commerce apps, need to render this content as raw HTML, coming from a database or a CMS. Today, there is no way in LWC to render raw HTML content both on the browser and the server. This proposal introduces the `lwc:inner-html` template directive to inject HTML content.
 
 ### Basic example
 
@@ -56,9 +56,9 @@ This proposal introduces a new `lwc:inner-html` directive to inject raw HTML con
 
 ### Runtime behavior
 
-At runtime the `lwc:inner-html` directive binds the directive value to the `Element.innerHTML` property. During each rendering cycle, the LWC engine diff the current value with its previous value. If the value changes between two rendering cycles, the LWC engine sets the element `innerHTML` property to the new value.
+At runtime the `lwc:inner-html` directive binds the directive value to the `Element.innerHTML` property. During each rendering cycle, the LWC engine diffs the current value with its previous value. If the value changes between two rendering cycles, the LWC engine sets the element `innerHTML` property to the new value.
 
-`Element.innerHTML` is a wellknown XSS sink. To prevent malicious content injection via this `lwc:inner-html` directive, a new `sanitizeHtmlContent` hook is introduced on the LWC engine. This hook is invoked during the LWC component rendering cycle and can be used to strip out malicious code from the content to be injected. The hook accepts a single `content` argument, which is the value passed to the `lwc:inner-html` directive. The `sanitizeHtmlContent` hook is expected to return the sanitized HTML content as a `string`. By default, the `sanitizeHtmlContent` hook will throw an error indicating that it needs to be overridden.
+`Element.innerHTML` is a well-known XSS sink. To prevent malicious content injection via this `lwc:inner-html` directive, a new `sanitizeHtmlContent` hook is introduced on the LWC engine. This hook is invoked during the LWC component rendering cycle and can be used to strip out malicious code from the content to be injected. The hook accepts a single `content` argument, which is the value passed to the `lwc:inner-html` directive. The `sanitizeHtmlContent` hook is expected to return the sanitized HTML content as a `string`. By default, the `sanitizeHtmlContent` hook will throw an error indicating that it needs to be overridden.
 
 You can override the `sanitizeHtmlContent` hook by calling the `setHooks` API. For example:
 
@@ -73,7 +73,7 @@ setHooks({
 });
 ```
 
-When running in native shadow, the shadow DOM style automatically gets applied to injected content. In synthetic shadow, the `lwc:inner-html` relies on the same mechanism than `lwc:dom="manual"` to apply the scoped styles to the manually injected content. The synthetic shadow DOM attaches a MutationObserver on the root element and watches for DOM changes in the subtree to apply the styling attributes.
+When running in native shadow, the shadow DOM style automatically gets applied to injected content. In synthetic shadow, the `lwc:inner-html` relies on the same mechanism as `lwc:dom="manual"` to apply the scoped styles to the manually injected content. The synthetic shadow DOM attaches a MutationObserver on the root element and watches for DOM changes in the subtree to apply the styling attributes.
 
 ### Compilation restrictions
 
@@ -133,7 +133,7 @@ It is also important to call out the opposite effect of injecting `<slot>` in na
 
 Different syntaxes for the `innerHTML` attribute are possible, but they finally lead to the same results. It is then more a matter of preference and consistency.
 
-Another solution would define a new binding syntax, like for example `${{myhtml}}` or `${html:myhtml}}`. But such a syntax could be used everywhere a binding is possible, including attribute values. This could lead to undefined behaviors why not providing any value. The proposed syntax makes sure that the `innerHTML` binding always applies to the content of an element.
+Another solution would define a new binding syntax, like for example `${{myhtml}}` or `${html:myhtml}}`. But such a syntax could be used everywhere a binding is possible, including attribute values. This could lead to undefined behaviors while not providing any value. The proposed syntax makes sure that the `innerHTML` binding always applies to the content of an element.
 
 ## Prior Art
 
@@ -143,7 +143,7 @@ Another solution would define a new binding syntax, like for example `${{myhtml}
 
 ## Adoption strategy
 
-Because the attribute uses the reserved `lwc:` prefix, there is no backward compatibility issue, and there is no potential name conflicts.
+Because the attribute uses the reserved `lwc:` prefix, there is no backward compatibility issue, and there are no potential name conflicts.
 
 ## How we teach this
 

--- a/text/0124-error-code-system.md
+++ b/text/0124-error-code-system.md
@@ -14,13 +14,13 @@ This proposal will address two items:
 
 This RFC focused on the compiler errors only, but some of the concepts can be applied later on to the runtime.
 
-Developers will replace assert blocks/statements with `invariant(condition, message)` calls. With invariant calls, during development mode, error messages will appear in the console in its full length; however in production mode, only a friendly URL with an errorCode will be shown. User can follow the URL to the Lightning Web Components site to read detailed error explanation. This minimizes amount of text being shipped and hides error verboseness in production code.
+Developers will replace assert blocks/statements with `invariant(condition, message)` calls. With invariant calls, during development mode, error messages will appear in the console in its full length; however in production mode, only a friendly URL with an errorCode will be shown. User can follow the URL to the Lightning Web Components site to read detailed error explanation. This minimizes the amount of text being shipped and hides error verboseness in production code.
 
 NOTE: This proposal mimics, with some deviations, logic from React's [Error Code system](https://reactjs.org/blog/2016/07/11/introducing-reacts-error-code-system.html).
-Please read over above react doc for it will help you follow current proposal.
+Please read over the above React doc for it will help you follow current proposal.
 
 
-# Lightning Web Components Error Code system will consist of following parts:
+# Lightning Web Components Error Code system will consist of the following parts:
 **1.** `errorCodes.json` -  json object with key:value pairs, where key is a unique error code and value is a unique message key. The message key is a result of concatenating error name-space and error-key ex:
 
 ```js
@@ -31,7 +31,7 @@ Please read over above react doc for it will help you follow current proposal.
 ```
 
 
-Error-code keys follow numeric sequence, where each sequence represents a collection of error codes related to an individual engine part ( ex: 100x - events, 200x - props, 300x - render ... ). Leading digit of the error code will represent a specific engine part and will help developers to quickly identify failing area ( any error starting with '1' is related to events for example ).
+Error-code keys follow numeric sequence, where each sequence represents a collection of error codes related to an individual engine part ( ex: 100x - events, 200x - props, 300x - render ... ). Leading digit of the error code will represent a specific engine part and will help developers to quickly identify failing area ( any error starting with '1' is related to events, for example ).
 NOTE: this file is append only - since these codes will be served on our website for documentation purposes and can potentially be referenced by support groups, these codes must not change.
 
 **2.** `errors.json` - json object with key:value pairs, where key is a unique error identifier and value is a message string ( see below for 'discussion needed' ). This message key becomes the value in the error-code map ( error-code inverse map is used during prod build to retrieve an error code by the message key - see below ). This is the part where Lightning Web Components deviates from React ( see more in info section for explanation ).
@@ -117,7 +117,7 @@ Cons:
 **Error Codes: Manually added vs Auto Generated**
 **Manual:**
 - full control of how code increments are being assigned.
-- no need to introduce babel pass to collect new error messages which are then used to increment error code sequences by adding new entires into errorCodes.json file
+- no need to introduce a babel pass to collect new error messages which are then used to increment error code sequences by adding new entires into errorCodes.json file
 
 **Auto Generated:**
 - No need to worry about manually maintaining error codes - babel pass will automatically create new error code entries if new error messages are added


### PR DESCRIPTION
## Summary
Fix 24 spelling and grammar errors across 5 RFC documents:

- **0000-intl.md** (10 fixes): `moninative`, `entitity`, `entitye`, `embeded`, `extra`/`exact` → `extract` (×2), subject-verb agreement, missing participle, grammar
- **0124-error-code-system.md** (5 fixes): missing articles (`the`, `a`), missing comma
- **0123-innerhtml-binding.md** (6 fixes): `wellknown` → `well-known`, `mechanism than` → `as`, `why` → `while`, subject-verb agreement (×2), `rendered` → `render`
- **0111-feature-flags.md** (2 fixes): `achieve` → `achieved`, subject-verb agreement
- **0000-focus-behavior.md** (1 fix): `recieve` → `receive`

## Test plan
- Documentation-only changes — no code modifications
- Verified each typo exists in the current default branch before fixing